### PR TITLE
Windows10 documentation for local install + rinkeby deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ There are two docker files in this repository. `Dockerfile` creates a plain Sona
 
 ## Manual setup
 
+### Linux / OS X
+
 Install dependencies
 
 ```npm install```
@@ -48,3 +50,26 @@ Make sure everything works
 ```
 npm run test
 ```
+
+### Windows 10
+
+On Windows, you will have to take a few extra steps to get everything to work:
+
+* Make sure that the Solidity source files in `contracts/` (and `test/`) have Unix-Style line endings (`LF`).
+
+One way to do this is enabling Unix-Style checkout for the project:
+```
+git config core.autocrlf input
+git fetch --all
+```
+If this causes problems for you, edit the `.sol` files manually.
+
+* Rename `truffle.js` to `truffle-config.js`.
+
+* In `package.json` change the line that starts with `extract-abi`. Add `node` before the path of the script, i.e. the line should read
+
+```
+"extract-abi": "node ./bin/extract-abi build/contracts/ModelRepository.json > build/ModelRepository.abi"
+```
+
+* Finally, follow the Linux instructions above.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ npm run test
 On Windows, you will have to take a few extra steps to get everything to work:
 
 * Make sure that the Solidity source files in `contracts/` (and `test/`) have Unix-Style line endings (`LF`).
-
 One way to do this is enabling Unix-Style checkout for the project:
 ```
 git config core.autocrlf input
@@ -67,9 +66,8 @@ If this causes problems for you, edit the `.sol` files manually.
 * Rename `truffle.js` to `truffle-config.js`.
 
 * In `package.json` change the line that starts with `extract-abi`. Add `node` before the path of the script, i.e. the line should read
-
 ```
 "extract-abi": "node ./bin/extract-abi build/contracts/ModelRepository.json > build/ModelRepository.abi"
 ```
 
-* Finally, follow the Linux instructions above.
+Finally, follow the Linux instructions above.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run test
 
 ### Windows 10
 
-On Windows, you will have to take a few extra steps to get everything to work:
+On Windows, you will have to take a few extra steps to get everything to work locally:
 
 * Make sure that the Solidity source files in `contracts/` (and `test/`) have Unix-Style line endings (`LF`).
 One way to do this is enabling Unix-Style checkout for the project:

--- a/rinkeby-deployment.md
+++ b/rinkeby-deployment.md
@@ -20,8 +20,6 @@
 
 **Note**: This is the first hacky docs for what I did to deploy the contract and attach to it. Feel free to improve this doc!
 
-All paths are MacOS specific.. might differ for you
-
 ## ⚙ prerequisites
 
 First you need to install [geth](https://geth.ethereum.org/) for running a local ethereum node
@@ -43,7 +41,10 @@ what's going to happen:
 
 _Creating the account using `geth account new` didn't work for me as it seems that the account is created for the main net and importing the account to testnet is not possible. Might be able to pull this off by moving files around._
 
-You attach to the `geth` with a REPL: `geth attach ~/Library/Ethereum/rinkeby/geth.ipc` (_On Windows:_ `geth attach \\.\pipe\geth.ipc`)
+You attach to the `geth` with a REPL:
+	_Linux:_ `geth attach ~/.ethereum/rinkeby/geth.ipc`,
+	_OS X:_ `geth attach ~/Library/Ethereum/rinkeby/geth.ipc`, 
+	_Windows:_ `geth attach \\.\pipe\geth.ipc`.
 
 If you type `eth.accounts` you should get an empty response `[]`
 
@@ -58,7 +59,7 @@ Repeat passphrase:
 "0xbf4696ecfa2d3697f98805d4166fdaeaf3b67944"
 ```
 
-Your private key is stored in a secret facility (_Linux/OS X:_ `~/Library/Ethereum/rinkeby/keystore`, _Windows:_  `%userprofile%\AppData\Roaming\Ethereum\rinkeby\keystore`). If you wish to view your account on [myetherwallet](https://www.myetherwallet.com/#view-wallet-info) just select the option of `Keystore File (UTC / JSON)` and point it to the file at this address. Enter your passphrase and you should see your account.
+Your private key is stored in a secret facility (_Linux:_ `~/.ethereum/rinkeby/keystore`, _OS X:_ `~/Library/Ethereum/rinkeby/keystore`, _Windows:_  `%userprofile%\AppData\Roaming\Ethereum\rinkeby\keystore`). If you wish to view your account on [myetherwallet](https://www.myetherwallet.com/#view-wallet-info) just select the option of `Keystore File (UTC / JSON)` and point it to the file at this address. Enter your passphrase and you should see your account.
 
 ### 3. fund your account
 

--- a/rinkeby-deployment.md
+++ b/rinkeby-deployment.md
@@ -43,7 +43,7 @@ what's going to happen:
 
 _Creating the account using `geth account new` didn't work for me as it seems that the account is created for the main net and importing the account to testnet is not possible. Might be able to pull this off by moving files around._
 
-You attach to the `geth` with a REPL: `geth attach ~/Library/Ethereum/rinkeby/geth.ipc`
+You attach to the `geth` with a REPL: `geth attach ~/Library/Ethereum/rinkeby/geth.ipc` (_On Windows:_ `geth attach \\.\pipe\geth.ipc`)
 
 If you type `eth.accounts` you should get an empty response `[]`
 
@@ -58,7 +58,7 @@ Repeat passphrase:
 "0xbf4696ecfa2d3697f98805d4166fdaeaf3b67944"
 ```
 
-Your private key is stored in a secret facility (`~/Library/Ethereum/rinkeby/keystore`). If you wish to view your account on [myetherwallet](https://www.myetherwallet.com/#view-wallet-info) just select the option of `Keystore File (UTC / JSON)` and point it to the file at this address. Enter your passphrase and you should see your account.
+Your private key is stored in a secret facility (_Linux/OS X:_ `~/Library/Ethereum/rinkeby/keystore`, _Windows:_  `%userprofile%\AppData\Roaming\Ethereum\rinkeby\keystore`). If you wish to view your account on [myetherwallet](https://www.myetherwallet.com/#view-wallet-info) just select the option of `Keystore File (UTC / JSON)` and point it to the file at this address. Enter your passphrase and you should see your account.
 
 ### 3. fund your account
 


### PR DESCRIPTION
@iamtrask : For `rinkeby-deployment.md` I did **not**  follow your advice and make a separate Section:  

The only differences here were two file system locations, so I simply added the changes inline because I think an extra Windows section would add a lot of unnecessary redundancy.